### PR TITLE
fix(block-buffer): workaround reservation issue

### DIFF
--- a/src/components/block-buffer.spec.ts
+++ b/src/components/block-buffer.spec.ts
@@ -6,7 +6,7 @@ import type { ChaingraphBlock } from '../types/chaingraph';
 import { BlockBuffer } from './block-buffer';
 
 const oneMB = 1_000_000;
-const maxBlockMB = 32_000_000;
+const maxExpectedBlockMB = oneMB;
 
 const fakeBlock = (size: number) => ({ sizeBytes: size } as ChaingraphBlock);
 
@@ -38,7 +38,7 @@ test('BlockBuffer: general use', (t) => {
   blockBuffer.reserveBlock();
   blockBuffer.reserveBlock();
   blockBuffer.reserveBlock();
-  t.deepEqual(blockBuffer.currentlyAllocatedSize(), 3 * maxBlockMB);
+  t.deepEqual(blockBuffer.currentlyAllocatedSize(), 3 * maxExpectedBlockMB);
   t.true(blockBuffer.isFull());
 
   blockBuffer.addBlock(fake1);
@@ -84,7 +84,7 @@ test('BlockBuffer: general use', (t) => {
   t.deepEqual(blockBuffer.currentlyAllocatedSize(), 0);
 });
 
-test('BlockBuffer: initial reservations require 32MB', (t) => {
+test('BlockBuffer: initial reservations require 1MB', (t) => {
   const blockBuffer = new BlockBuffer({
     freedSpaceCallback: () => {
       t.pass();
@@ -92,6 +92,6 @@ test('BlockBuffer: initial reservations require 32MB', (t) => {
     targetSize: oneMB,
   });
   blockBuffer.reserveBlock();
-  t.deepEqual(blockBuffer.currentlyAllocatedSize(), maxBlockMB);
+  t.deepEqual(blockBuffer.currentlyAllocatedSize(), maxExpectedBlockMB);
   t.true(blockBuffer.isFull());
 });

--- a/src/components/block-buffer.ts
+++ b/src/components/block-buffer.ts
@@ -92,8 +92,10 @@ export class BlockBuffer {
      *
      * After blocks have been downloaded, the expected size of each next block
      * is the average of all currently buffered blocks.
+     *
+     * TODO: future proofing: `assumedMaxBlockSize` should be 32MB, but setting it that high currently causes intermittent e2e test failures when `this.count()` is `0` and reservations take up all available space. There may be a bug with reservations not being released.
      */
-    const assumedMaxBlockSize = 32_000_000;
+    const assumedMaxBlockSize = 1_000_000;
     const currentTotal = this.currentTotalBytes();
     const currentLength = this.bufferedBlocks.length;
     const averageBlock =


### PR DESCRIPTION
E2e tests are failing intermittently when reservations exhaust the target buffer size. Working
around for now.