### PR TITLE
Change block insert trigger to use index lookup

### DIFF
--- a/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
+++ b/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
@@ -291,12 +291,12 @@ WITH accepted_transactions AS (
 	SELECT node_internal_id, transaction_internal_id, accepted_at FROM block_transaction INNER JOIN new_table ON block_transaction.block_internal_id = new_table.block_internal_id
 ),
 newly_spent AS (
-	SELECT accepted_transactions.node_internal_id, accepted_transactions.transaction_internal_id, accepted_transactions.accepted_at, input.outpoint_transaction_hash, input.outpoint_index
+	SELECT accepted_transactions.node_internal_id, accepted_transactions.transaction_internal_id, accepted_transactions.accepted_at, input.outpoint_index
 		FROM input INNER JOIN accepted_transactions ON input.transaction_internal_id = accepted_transactions.transaction_internal_id
 ),
 accepted_and_replaced_transactions AS (
     SELECT newly_spent.node_internal_id, input.transaction_internal_id, CASE WHEN input.transaction_internal_id != newly_spent.transaction_internal_id THEN newly_spent.accepted_at ELSE NULL END AS replaced_at
-        FROM input INNER JOIN newly_spent ON input.outpoint_transaction_hash = newly_spent.outpoint_transaction_hash AND input.outpoint_index = newly_spent.outpoint_index
+        FROM input INNER JOIN newly_spent ON input.transaction_internal_id = newly_spent.transaction_internal_id AND input.outpoint_index = newly_spent.outpoint_index
         WHERE input.outpoint_transaction_hash != '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea
 --        GROUP BY newly_spent.node_internal_id, input.transaction_internal_id, replaced -- doesn't improve performance
 ),


### PR DESCRIPTION
This PR changes the `INNER JOIN` condition to lookup inputs by indexed columns `transaction_internal_id` and `outpoint_index`. Otherwise full sequence scan is performed taking up to between 12-18 minutes on a fully synched instance.