### PR TITLE
Add 'locking_bytecode_hex' computed field to 'output' table

### DIFF
--- a/images/hasura/hasura-data/metadata/databases/default/tables/public_output.yaml
+++ b/images/hasura/hasura-data/metadata/databases/default/tables/public_output.yaml
@@ -22,6 +22,11 @@ computed_fields:
       function:
         name: output_locking_bytecode_pattern
         schema: public
+  - name: locking_bytecode_hex
+    definition:
+      function:
+        name: output_locking_bytecode_hex
+        schema: public
 select_permissions:
   - role: public
     permission:
@@ -36,5 +41,6 @@ select_permissions:
         - nonfungible_token_commitment
       computed_fields:
         - locking_bytecode_pattern
+        - locking_bytecode_hex
       filter: {}
       limit: 5000

--- a/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
+++ b/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
@@ -525,6 +525,13 @@ AS $$
 $$;
 COMMENT ON FUNCTION output_locking_bytecode_pattern (output) IS 'Extract the first byte of each instruction for the locking bytecode of an output. The resulting pattern excludes the contents of pushed values such that similar bytecode sequences produce the same pattern.';
 
+CREATE FUNCTION output_locking_bytecode_hex(output_row output) RETURNS text
+  LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT encode($1.locking_bytecode, 'hex');
+$$;
+COMMENT ON FUNCTION output_locking_bytecode_hex (output) IS 'Transform output locking bytecode to hex string.';
+
 CREATE FUNCTION input_unlocking_bytecode_pattern(input_row input) RETURNS text
   LANGUAGE sql IMMUTABLE
 AS $$


### PR DESCRIPTION
With this computed field we now can flexibly lookup/constrain various locking bytecodes with custom matches.

Available at https://chaingraph.pat.mn

Most basic usage:

```
...
where: {
  outputs: {
    locking_bytecode_hex: {_like: "6a%"}
  }
}
...
```