### PR TITLE
Handle unhandled exceptions in parse_bytecode_pattern_redeem

### DIFF
--- a/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
+++ b/images/hasura/hasura-data/migrations/default/1616195337538_init/up.sql
@@ -635,6 +635,7 @@ BEGIN
   ELSE
     RETURN parse_bytecode_pattern(maybe_redeem);
   END IF;
+EXCEPTION WHEN OTHERS THEN RETURN NULL;
 END;
 $$;
 COMMENT ON FUNCTION parse_bytecode_pattern_redeem (bytea) IS 'Parse VM unlocking bytecode to identify the final instruction. If the last instruction is a push, attempt to parse its contents as P2SH redeem bytecode, extracting the first byte of each instruction into a bytecode pattern (excluding length bytes and pushed data). If the last instruction is not a push, return NULL.';


### PR DESCRIPTION
Fixes #55

`parse_bytecode_pattern_redeem_fix` tries to parse coinbase unlocking bytecodes which (are non-scripts) and fails pushdata interpretations. Added unhandled exception handler to fix this.